### PR TITLE
refactor: PK 컬럼 네이밍 'id' 통일화 및 token 디렉터리 생성

### DIFF
--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/entity/Article.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/entity/Article.java
@@ -21,7 +21,6 @@ public class Article extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "article_id")
     private Long id;
 
     @Column(nullable = false, length = 200)
@@ -37,7 +36,6 @@ public class Article extends BaseEntity {
     private int dislikesCount;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id")
     private User user;
 
     @Builder

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/entity/ArticleComment.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/entity/ArticleComment.java
@@ -15,18 +15,15 @@ import java.util.Objects;
 public class ArticleComment extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id")
     private Long id;
 
     @Column(nullable = false, length = 10000)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "article_id")
     private Article article;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id")
     private User user;
 
     private ArticleComment(String content, Article article, User user) {

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/UserPrincipal.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/UserPrincipal.java
@@ -1,4 +1,4 @@
-package com.study.spadeworker.domain.auth.entity;
+package com.study.spadeworker.domain.auth;
 
 import com.study.spadeworker.domain.user.entity.User;
 import com.study.spadeworker.domain.user.entity.constant.ProviderType;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/filter/TokenAuthenticationFilter.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/filter/TokenAuthenticationFilter.java
@@ -1,9 +1,8 @@
 package com.study.spadeworker.domain.auth.jwt.filter;
 
-import com.study.spadeworker.domain.auth.exception.AuthErrorCode;
 import com.study.spadeworker.domain.auth.exception.jwt.TokenValidFailedException;
-import com.study.spadeworker.domain.auth.jwt.AuthToken;
-import com.study.spadeworker.domain.auth.jwt.AuthTokenProvider;
+import com.study.spadeworker.domain.auth.jwt.token.AuthToken;
+import com.study.spadeworker.domain.auth.jwt.token.AuthTokenProvider;
 import com.study.spadeworker.global.util.HeaderUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/service/TokenService.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/service/TokenService.java
@@ -1,9 +1,9 @@
 package com.study.spadeworker.domain.auth.jwt.service;
 
-import com.study.spadeworker.domain.auth.jwt.AuthToken;
-import com.study.spadeworker.domain.auth.jwt.AuthTokenProvider;
-import com.study.spadeworker.domain.auth.jwt.UserRefreshToken;
-import com.study.spadeworker.domain.auth.jwt.UserRefreshTokenRepository;
+import com.study.spadeworker.domain.auth.jwt.token.AuthToken;
+import com.study.spadeworker.domain.auth.jwt.token.AuthTokenProvider;
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshToken;
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshTokenRepository;
 import com.study.spadeworker.domain.user.entity.constant.RoleType;
 import com.study.spadeworker.global.config.properties.AppProperties;
 import io.jsonwebtoken.Claims;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/AuthToken.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/AuthToken.java
@@ -1,4 +1,4 @@
-package com.study.spadeworker.domain.auth.jwt;
+package com.study.spadeworker.domain.auth.jwt.token;
 
 import io.jsonwebtoken.*;
 import lombok.Getter;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/AuthTokenProvider.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/AuthTokenProvider.java
@@ -1,4 +1,4 @@
-package com.study.spadeworker.domain.auth.jwt;
+package com.study.spadeworker.domain.auth.jwt.token;
 
 import com.study.spadeworker.domain.auth.exception.jwt.TokenValidFailedException;
 import io.jsonwebtoken.Claims;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/UserRefreshToken.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/UserRefreshToken.java
@@ -1,4 +1,4 @@
-package com.study.spadeworker.domain.auth.jwt;
+package com.study.spadeworker.domain.auth.jwt.token;
 
 import com.study.spadeworker.global.config.audit.BaseTimeEntity;
 import lombok.AccessLevel;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/UserRefreshTokenRepository.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/jwt/token/UserRefreshTokenRepository.java
@@ -1,5 +1,6 @@
-package com.study.spadeworker.domain.auth.jwt;
+package com.study.spadeworker.domain.auth.jwt.token;
 
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,10 +1,10 @@
 package com.study.spadeworker.domain.auth.oauth.handler;
 
 import com.study.spadeworker.domain.auth.exception.oauth.InvalidLoginRedirectUriException;
-import com.study.spadeworker.domain.auth.jwt.AuthToken;
-import com.study.spadeworker.domain.auth.jwt.AuthTokenProvider;
-import com.study.spadeworker.domain.auth.jwt.UserRefreshToken;
-import com.study.spadeworker.domain.auth.jwt.UserRefreshTokenRepository;
+import com.study.spadeworker.domain.auth.jwt.token.AuthToken;
+import com.study.spadeworker.domain.auth.jwt.token.AuthTokenProvider;
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshToken;
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshTokenRepository;
 import com.study.spadeworker.domain.auth.oauth.info.OAuth2UserInfo;
 import com.study.spadeworker.domain.auth.oauth.info.OAuth2UserInfoFactory;
 import com.study.spadeworker.domain.auth.oauth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/auth/oauth/service/CustomOAuth2UserService.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,6 +1,6 @@
 package com.study.spadeworker.domain.auth.oauth.service;
 
-import com.study.spadeworker.domain.auth.entity.UserPrincipal;
+import com.study.spadeworker.domain.auth.UserPrincipal;
 import com.study.spadeworker.domain.auth.exception.oauth.OAuthProviderMissMatchException;
 import com.study.spadeworker.domain.auth.oauth.info.OAuth2UserInfo;
 import com.study.spadeworker.domain.auth.oauth.info.OAuth2UserInfoFactory;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/user/entity/User.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/user/entity/User.java
@@ -16,7 +16,6 @@ import javax.persistence.*;
 public class User extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
     private Long id;
 
     @Column(nullable = false, length = 200, unique = true)

--- a/spadeworker/src/main/java/com/study/spadeworker/global/config/security/JwtConfig.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/global/config/security/JwtConfig.java
@@ -1,6 +1,6 @@
 package com.study.spadeworker.global.config.security;
 
-import com.study.spadeworker.domain.auth.jwt.AuthTokenProvider;
+import com.study.spadeworker.domain.auth.jwt.token.AuthTokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spadeworker/src/main/java/com/study/spadeworker/global/config/security/SecurityConfig.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/global/config/security/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.study.spadeworker.global.config.security;
 
-import com.study.spadeworker.domain.auth.jwt.AuthTokenProvider;
-import com.study.spadeworker.domain.auth.jwt.UserRefreshTokenRepository;
+import com.study.spadeworker.domain.auth.jwt.token.AuthTokenProvider;
+import com.study.spadeworker.domain.auth.jwt.token.UserRefreshTokenRepository;
 import com.study.spadeworker.domain.auth.jwt.filter.CustomAccessDeniedHandler;
 import com.study.spadeworker.domain.auth.jwt.filter.CustomAuthenticationEntryPoint;
 import com.study.spadeworker.domain.auth.jwt.filter.TokenAuthenticationFilter;


### PR DESCRIPTION
* PK 컬럼의 이름을 모두 id로 통일하도록 결정하였고 이를 적용하였다.
* auth 도메인의 token 디렉터리를 생성하고 적용하였다.