### PR TITLE
게시글 리스트 조회 및 해시태그 다중 검색/키워드 검색/정렬 기능 통합

### DIFF
--- a/spadeworker/src/main/generated/com/study/spadeworker/domain/article/entity/QArticle.java
+++ b/spadeworker/src/main/generated/com/study/spadeworker/domain/article/entity/QArticle.java
@@ -1,0 +1,81 @@
+package com.study.spadeworker.domain.article.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QArticle is a Querydsl query type for Article
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QArticle extends EntityPathBase<Article> {
+
+    private static final long serialVersionUID = -1651811824L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QArticle article = new QArticle("article");
+
+    public final com.study.spadeworker.global.config.audit.QBaseEntity _super = new com.study.spadeworker.global.config.audit.QBaseEntity(this);
+
+    public final QArticleCategory articleCategory;
+
+    public final com.study.spadeworker.domain.board.entity.QBoard board;
+
+    public final ListPath<ArticleComment, QArticleComment> comments = this.<ArticleComment, QArticleComment>createList("comments", ArticleComment.class, QArticleComment.class, PathInits.DIRECT2);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    //inherited
+    public final StringPath createdBy = _super.createdBy;
+
+    public final NumberPath<Integer> dislikesCount = createNumber("dislikesCount", Integer.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Integer> likesCount = createNumber("likesCount", Integer.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    //inherited
+    public final StringPath modifiedBy = _super.modifiedBy;
+
+    public final StringPath title = createString("title");
+
+    public final com.study.spadeworker.domain.user.entity.QUser user;
+
+    public QArticle(String variable) {
+        this(Article.class, forVariable(variable), INITS);
+    }
+
+    public QArticle(Path<? extends Article> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QArticle(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QArticle(PathMetadata metadata, PathInits inits) {
+        this(Article.class, metadata, inits);
+    }
+
+    public QArticle(Class<? extends Article> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.articleCategory = inits.isInitialized("articleCategory") ? new QArticleCategory(forProperty("articleCategory")) : null;
+        this.board = inits.isInitialized("board") ? new com.study.spadeworker.domain.board.entity.QBoard(forProperty("board"), inits.get("board")) : null;
+        this.user = inits.isInitialized("user") ? new com.study.spadeworker.domain.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/spadeworker/src/main/generated/com/study/spadeworker/domain/article/entity/QArticleCategory.java
+++ b/spadeworker/src/main/generated/com/study/spadeworker/domain/article/entity/QArticleCategory.java
@@ -1,0 +1,47 @@
+package com.study.spadeworker.domain.article.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QArticleCategory is a Querydsl query type for ArticleCategory
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QArticleCategory extends EntityPathBase<ArticleCategory> {
+
+    private static final long serialVersionUID = 1018522414L;
+
+    public static final QArticleCategory articleCategory = new QArticleCategory("articleCategory");
+
+    public final com.study.spadeworker.global.config.audit.QBaseTimeEntity _super = new com.study.spadeworker.global.config.audit.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath title = createString("title");
+
+    public QArticleCategory(String variable) {
+        super(ArticleCategory.class, forVariable(variable));
+    }
+
+    public QArticleCategory(Path<? extends ArticleCategory> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QArticleCategory(PathMetadata metadata) {
+        super(ArticleCategory.class, metadata);
+    }
+
+}
+

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/controller/ArticleController.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/controller/ArticleController.java
@@ -102,7 +102,7 @@ public class ArticleController {
     public ListResult<ArticleDto> getArticles(
             @PathVariable final Long boardId,
             ArticlesViewOptionDto articlesViewOptionDto,
-            @PageableDefault(size = 3) Pageable pageable
+            @PageableDefault(size = 10) Pageable pageable
     ) {
         return responseService.getListResult(
                 OK.value(),

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/controller/ArticleController.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/controller/ArticleController.java
@@ -1,8 +1,8 @@
 package com.study.spadeworker.domain.article.controller;
 
-import com.study.spadeworker.domain.article.constant.OrderType;
 import com.study.spadeworker.domain.article.dto.ArticleWithCommentsDto;
 import com.study.spadeworker.domain.article.dto.article.ArticleDto;
+import com.study.spadeworker.domain.article.dto.article.ArticlesViewOptionDto;
 import com.study.spadeworker.domain.article.dto.article.CreateArticleDto;
 import com.study.spadeworker.domain.article.dto.article.UpdateArticleDto;
 import com.study.spadeworker.domain.article.service.ArticleService;
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -97,20 +96,20 @@ public class ArticleController {
     }
 
     /**
-     * 해당 게시판의 게시글 전체 리스트 조회 및 정렬
+     * 해당 게시판의 조건에 맞는 게시글 전체 조회 및 정렬 API
      */
     @GetMapping("/board/{boardId}/articles")
-    public ListResult<ArticleDto> getAllArticle(
+    public ListResult<ArticleDto> getArticles(
             @PathVariable final Long boardId,
-            @RequestParam(value = "order", required = false) OrderType orderType,
+            ArticlesViewOptionDto articlesViewOptionDto,
             @PageableDefault(size = 3) Pageable pageable
     ) {
         return responseService.getListResult(
                 OK.value(),
                 "성공적으로 게시글이 조회되었습니다.",
-                articleService.getAllArticle(
+                articleService.getArticles(
                         boardId,
-                        orderType,
+                        articlesViewOptionDto,
                         pageable
                 ).getContent()
         );

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/dto/article/ArticlesViewOptionDto.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/dto/article/ArticlesViewOptionDto.java
@@ -1,0 +1,16 @@
+package com.study.spadeworker.domain.article.dto.article;
+
+import com.study.spadeworker.domain.article.constant.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ArticlesViewOptionDto {
+
+    private final OrderType orderType;
+
+    private final String hashtag;
+
+    private final String keyword;
+}

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/dto/article/ArticlesViewOptionDto.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/dto/article/ArticlesViewOptionDto.java
@@ -1,14 +1,14 @@
 package com.study.spadeworker.domain.article.dto.article;
 
 import com.study.spadeworker.domain.article.constant.OrderType;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class ArticlesViewOptionDto {
 
-    private final OrderType orderType;
+    private final OrderType order;
 
     private final String hashtag;
 

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepository.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepository.java
@@ -1,41 +1,11 @@
 package com.study.spadeworker.domain.article.repository;
 
-import com.querydsl.core.types.dsl.DateTimeExpression;
-import com.querydsl.core.types.dsl.StringExpression;
 import com.study.spadeworker.domain.article.entity.Article;
-import com.study.spadeworker.domain.article.entity.QArticle;
-import com.study.spadeworker.domain.board.entity.Board;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
-import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
-import org.springframework.data.querydsl.binding.QuerydslBindings;
-import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends
-        JpaRepository<Article, Long> {
-    /**
-     * 최신순 정렬
-     */
-    Page<Article> findByBoard_IdOrderByCreatedAtDesc(
-            Long boardId,
-            Pageable pageable);
-
-    /**
-     * 댓글 많은순 조회
-     */
-    @Query("select a from Article a where a.board.id = :boardId" +
-            " order by a.comments.size desc ")
-    Page<Article> findByBoard_IdOrderByCommentsCount(
-            @Param("boardId") Long boardId,
-            Pageable pageable);
-
-    /**
-     * 좋아요 많은순 조회
-     */
-    Page<Article> findByBoard_IdOrderByLikesCountDesc(
-            Long boardId,
-            Pageable pageable);
+        JpaRepository<Article, Long>,
+        QuerydslPredicateExecutor<Article>,
+        ArticleRepositoryCustom {
 }

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustom.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustom.java
@@ -1,0 +1,19 @@
+package com.study.spadeworker.domain.article.repository;
+
+import com.study.spadeworker.domain.article.constant.OrderType;
+import com.study.spadeworker.domain.article.dto.article.ArticlesViewOptionDto;
+import com.study.spadeworker.domain.article.entity.Article;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ArticleRepositoryCustom {
+
+    /**
+     * 조건에 맞는 게시글 목록 조회
+     */
+    Page<Article> getArticlesByBoard(
+            Long boardId,
+            ArticlesViewOptionDto articlesViewOptionDto,
+            Pageable pageable
+    );
+}

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustomImpl.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,99 @@
+package com.study.spadeworker.domain.article.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.study.spadeworker.domain.article.constant.OrderType;
+import com.study.spadeworker.domain.article.dto.article.ArticlesViewOptionDto;
+import com.study.spadeworker.domain.article.entity.Article;
+import com.study.spadeworker.domain.article.entity.QArticle;
+import com.study.spadeworker.domain.article.entity.QArticleHashtag;
+import com.study.spadeworker.global.util.StringUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport
+        implements ArticleRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    public ArticleRepositoryCustomImpl(EntityManager em) {
+        super(Article.class);
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Article> getArticlesByBoard(
+            Long boardId,
+            ArticlesViewOptionDto articlesViewOptionDto,
+            Pageable pageable
+    ) {
+        QArticle article = QArticle.article;
+        QArticleHashtag articleHashtag = QArticleHashtag.articleHashtag;
+
+        List<Article> articles = queryFactory.selectFrom(article)
+                .leftJoin(articleHashtag).on(articleHashtag.article.eq(article))
+                .where(
+                        QArticle.article.board.id.eq(boardId),
+                        searchByKeyword(articlesViewOptionDto.getKeyword()),
+                        checkAllHashtag(articlesViewOptionDto.getHashtag())
+                )
+                .distinct()
+                .orderBy(getOrderOption(articlesViewOptionDto.getOrder()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return new PageImpl<>(articles);
+    }
+
+    // 정렬 옵션에 따른 정렬
+    private OrderSpecifier<?> getOrderOption(OrderType orderType) {
+        QArticle article = QArticle.article;
+        if (orderType == null || orderType == OrderType.RECENT) {
+            return article.createdAt.desc();
+        } else {
+            return switch (orderType) {
+                case COMMENT -> article.comments.size().desc();
+                case LIKES -> article.likesCount.desc();
+                default -> article.createdAt.desc();
+            };
+        }
+    }
+
+    // 검색어로 검색
+    private BooleanExpression searchByKeyword(String keyword) {
+        QArticle article = QArticle.article;
+        return keyword == null ? null :
+                article.title.like("%" + keyword + "%")
+                        .or(article.content.like("%" + keyword + "%"));
+    }
+
+    // Hashtag 검색
+    private BooleanExpression searchByHashtag(String hashtag) {
+        QArticleHashtag articleHashtag = QArticleHashtag.articleHashtag;
+        return hashtag == null ? null :
+                QArticle.article.id.in(
+                        queryFactory.select(
+                                articleHashtag.article.id
+                        ).from(articleHashtag).where(articleHashtag.hashtag.title.eq(hashtag)));
+    }
+
+    // 여러개의 해시태그가 모두 포함되어있는지 검사하는 Builder
+    private BooleanBuilder checkAllHashtag(String hashtag) {
+        List<String> hashtags = StringUtil.splitParameter(hashtag, ",");
+        BooleanBuilder builder = new BooleanBuilder();
+        if (hashtags != null && hashtags.size() != 0) {
+            for (String tag : hashtags) {
+                builder.and(searchByHashtag(tag));
+            }
+        }
+        return builder;
+    }
+}
+

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/service/ArticleService.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/service/ArticleService.java
@@ -1,8 +1,8 @@
 package com.study.spadeworker.domain.article.service;
 
-import com.study.spadeworker.domain.article.constant.OrderType;
-import com.study.spadeworker.domain.article.dto.*;
+import com.study.spadeworker.domain.article.dto.ArticleWithCommentsDto;
 import com.study.spadeworker.domain.article.dto.article.ArticleDto;
+import com.study.spadeworker.domain.article.dto.article.ArticlesViewOptionDto;
 import com.study.spadeworker.domain.article.dto.article.CreateArticleDto;
 import com.study.spadeworker.domain.article.dto.article.UpdateArticleDto;
 import com.study.spadeworker.domain.article.dto.articleComment.ArticleCommentDto;
@@ -62,7 +62,7 @@ public class ArticleService {
                 request.getTitle(),
                 request.getContent(),
                 getArticleCategoryEntity(request.getArticleCategory())
-                );
+        );
 
         // 해시태그 변경 적용
         hashtagService.updateArticleHashtag(request.getHashtagList(), article);
@@ -103,37 +103,29 @@ public class ArticleService {
     }
 
     /**
-     * 특정 게시판 모든 게시글 조회 및 정렬
+     * 특정 게시판의 조건에 맞는 모든 게시글 조회 및 정렬 비즈니스 로직
      */
     @Transactional(readOnly = true)
-    public Page<ArticleDto> getAllArticle(
+    public Page<ArticleDto> getArticles(
             Long boardId,
-            OrderType orderType,
+            ArticlesViewOptionDto articlesViewOptionDto,
             Pageable pageable) {
 
-        if (orderType == null || orderType == OrderType.RECENT) {
-            return articleRepository.
-                    findByBoard_IdOrderByCreatedAtDesc(boardId, pageable)
-                    .map(this::convertArticleToArticleDto);
-        }
+        int size = articleRepository.getArticlesByBoard(boardId, articlesViewOptionDto, pageable).getContent().size();
+        System.out.println("몇개 나와요? : " + size);
 
-        return switch (orderType) {
-            case RECENT -> articleRepository.
-                    findByBoard_IdOrderByCreatedAtDesc(boardId, pageable)
-                    .map(this::convertArticleToArticleDto);
-            case LIKES -> articleRepository.
-                    findByBoard_IdOrderByLikesCountDesc(boardId, pageable)
-                    .map(this::convertArticleToArticleDto);
-            case COMMENT -> articleRepository.
-                    findByBoard_IdOrderByCommentsCount(boardId, pageable)
-                    .map(this::convertArticleToArticleDto);
-        };
+        return articleRepository
+                .getArticlesByBoard(
+                        boardId,
+                        articlesViewOptionDto,
+                        pageable
+                ).map(this::convertArticleToArticleDto);
     }
 
     // 게시글 Entity 조회 메서드
     @Transactional(readOnly = true)
     public Article getArticleEntity(Long
-                                             articleId) {
+                                            articleId) {
         return articleRepository.findById(articleId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글이 존재하지 않습니다."));
     }

--- a/spadeworker/src/main/java/com/study/spadeworker/global/util/StringUtil.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/global/util/StringUtil.java
@@ -1,0 +1,10 @@
+package com.study.spadeworker.global.util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StringUtil {
+    public static List<String> splitParameter(String input, String separator) {
+        return input == null ? null : Arrays.asList(input.split(separator));
+    }
+}


### PR DESCRIPTION
다음과 같은 기능을 개발하였다.
* 특정 게시판의 전체 게시물 조회 및 페이징
* 아무런 옵션(파라미터)이 없을 경우 최신 순 정렬 및 페이징
* 게시물 정렬
  * 최신 순
  * 댓글 많은 순
  * 좋아요 많은 순
* 게시물 키워드 검색
  * 게시물 제목
  * 게시물 본문
* 게시물 해시태그 다중 검색
  * 게시물의 해시태그를 매칭 및 조회

추가로 다음과 같은 부분을 고려해서 꼭 리펙토링 해야한다.
* 하나의 게시글에 지정할 수 있는 해시태그의 개수를 최대 10개로 제한
* 다중 해시태그 검색을 구현하기 위해 사용한 "in subquery" 방식의 쿼리문을 더 좋은 방식을 찾아본 후 개선해볼 것!!

This closes #27 
