### PR TITLE
게시물당 해시태그를 최대 10개로 제한하도록 리펙토링

### DIFF
--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustom.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/repository/ArticleRepositoryCustom.java
@@ -1,6 +1,5 @@
 package com.study.spadeworker.domain.article.repository;
 
-import com.study.spadeworker.domain.article.constant.OrderType;
 import com.study.spadeworker.domain.article.dto.article.ArticlesViewOptionDto;
 import com.study.spadeworker.domain.article.entity.Article;
 import org.springframework.data.domain.Page;

--- a/spadeworker/src/main/java/com/study/spadeworker/domain/article/service/ArticleService.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/domain/article/service/ArticleService.java
@@ -38,6 +38,10 @@ public class ArticleService {
      * 게시글 생성 비즈니스
      */
     public Long createArticle(CreateArticleDto.Request request) {
+
+        // 해시태그 개수 체크
+        checkHashtagCount(request.getHashtagList());
+
         Article savedArticle = articleRepository.saveAndFlush(
                 Article.builder()
                         .title(request.getTitle())
@@ -57,6 +61,10 @@ public class ArticleService {
      * 게시글 수정 비즈니스
      */
     public Long updateArticle(Long articleId, UpdateArticleDto.Request request) {
+
+        // 해시태그 개수 체크
+        checkHashtagCount(request.getHashtagList());
+
         Article article = getArticleEntity(articleId);
         article.update(
                 request.getTitle(),
@@ -145,5 +153,14 @@ public class ArticleService {
                 userService.getUserAccountDto(article.getUser()),
                 hashtagService.getArticleHashtagList(article)
         );
+    }
+
+    // Hashtag 개수 체크
+    private boolean checkHashtagCount(List<String> hashtagList) {
+        if (hashtagList.size() > 10) {
+            throw new IllegalArgumentException("해시태그 개수가 10개를 초과하였습니다.");
+        }
+
+        return true;
     }
 }

--- a/spadeworker/src/main/resources/application.yml
+++ b/spadeworker/src/main/resources/application.yml
@@ -7,13 +7,13 @@ spring:
     password: ${spring.datasource.password}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
         format_sql: true
-    defer-datasource-initialization: true
-  sql.init.mode: always
+#    defer-datasource-initialization: true
+#  sql.init.mode: always
   # OAuth Config
   security:
     oauth2.client:

--- a/spadeworker/src/main/resources/data.sql
+++ b/spadeworker/src/main/resources/data.sql
@@ -1,88 +1,88 @@
--- 사용자 권한 테스트 데이터
-insert into role (authority, created_at, modified_at) values ('USER', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
-insert into role (authority, created_at, modified_at) values ('ADMIN', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
-insert into role (authority, created_at, modified_at) values ('BOARD_HOST', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
-
--- 게시판 카테고리 테스트 데이터
-insert into board_category (title, created_at, modified_at) values ('프로그래밍', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into board_category (title, created_at, modified_at) values ('취미', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into board_category (title, created_at, modified_at) values ('일상', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into board_category (title, created_at, modified_at) values ('예능', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
--- 사용자 테스트 데이터
-insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
-    values ('testerId1', 'testerPw1234', '게시글 작성자', 'tester photo', 'tester1@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
-    ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
-insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
-values ('testerId2', 'testerPw1234', '댓글 작성자', 'tester photo', 'tester2@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
-    ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
-insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
-values ('testerId3', 'testerPw1234', '대댓글 반박자', 'tester photo', 'tester3@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
-    ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
-
--- 게시판 테스트 데이터
-insert into board(title, description, image_url, user_id, board_category_id, created_at, created_by, modified_at, modified_by)
-    values ('스프링 게시판', '스!프!링! 시작해볼까요?', 'img_url aaaa', 1, 1, now(), 'tester', now(), 'tester')
-    ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
--- 게시글 카테고리 테스트 데이터
-insert into article_category (title, created_at, modified_at) values ('잡담', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into article_category (title, created_at, modified_at) values ('질문', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into article_category (title, created_at, modified_at) values ('홍보/모집', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into article_category (title, created_at, modified_at) values ('공지 사항', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-insert into article_category (title, created_at, modified_at) values ('이벤트', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
--- 게시글 테스트 데이터
-insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
-    values ("게시글1 제목입니다!!", "게겍게겍ㄲ", 10, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
-        ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
-insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
-values ("게시글2 제목입니다!!", "게겍게겍ㄲ", 5, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
-    ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
-insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
-values ("게시글3 제목입니다!!", "게겍게겍ㄲ", 100, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
-    ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
-insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
-values ("게시글4 제목입니다!!", "게겍게겍ㄲ", 1, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
-    ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
-insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
-values ("게시글 제목입니다5!!", "게겍게겍ㄲ", 54, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
-    ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
-
--- 게시글 최상위 댓글 테스트 데이터
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-    values ('댓글1 입니다!!!', 0, 0, 0, 2, 2, NULL, NULL, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자') ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('댓글2 입니다!!!', 0, 0, 0, 2, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('댓글3 입니다!!!', 0, 0, 0, 3, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('댓글4 입니다!!!', 0, 0, 0, 1, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('댓글5 입니다!!!', 0, 0, 0, 1, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-
--- 게시글 대댓글 테스트 데이터
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('대댓글5 입니다!!!', 0, 0, 1, 4, 3, 3, NULL, now(), '대댓글 작성자', now(), '대댓글 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('대댓글5 입니다!!!', 0, 0, 1, 4, 3, 3, NULL, now(), '대댓글 작성자', now(), '대댓글 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
-
-insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
-values ('전 님 의견 반박합니다!!!!!!!', 0, 0, 1, 4, 3, 3, 3, now(), '대댓글 작성자', now(), '대댓글 작성자')
-    ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+-- -- 사용자 권한 테스트 데이터
+-- insert into role (authority, created_at, modified_at) values ('USER', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
+-- insert into role (authority, created_at, modified_at) values ('ADMIN', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
+-- insert into role (authority, created_at, modified_at) values ('BOARD_HOST', now(), now()) ON DUPLICATE KEY UPDATE `authority`=VALUES(`authority`);
+--
+-- -- 게시판 카테고리 테스트 데이터
+-- insert into board_category (title, created_at, modified_at) values ('프로그래밍', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into board_category (title, created_at, modified_at) values ('취미', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into board_category (title, created_at, modified_at) values ('일상', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into board_category (title, created_at, modified_at) values ('예능', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- -- 사용자 테스트 데이터
+-- insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
+--     values ('testerId1', 'testerPw1234', '게시글 작성자', 'tester photo', 'tester1@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
+--     ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
+-- insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
+-- values ('testerId2', 'testerPw1234', '댓글 작성자', 'tester photo', 'tester2@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
+--     ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
+-- insert into user(login_id, password, name, profile_img_url, email, description, provider_type, status, created_at, modified_at)
+-- values ('testerId3', 'testerPw1234', '대댓글 반박자', 'tester photo', 'tester3@email.com', 'This is test account', 'LOCAL', 'ACTIVE', now(), now())
+--     ON DUPLICATE KEY UPDATE `login_id`=VALUES(`login_id`);
+--
+-- -- 게시판 테스트 데이터
+-- insert into board(title, description, image_url, user_id, board_category_id, created_at, created_by, modified_at, modified_by)
+--     values ('스프링 게시판', '스!프!링! 시작해볼까요?', 'img_url aaaa', 1, 1, now(), 'tester', now(), 'tester')
+--     ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- -- 게시글 카테고리 테스트 데이터
+-- insert into article_category (title, created_at, modified_at) values ('잡담', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into article_category (title, created_at, modified_at) values ('질문', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into article_category (title, created_at, modified_at) values ('홍보/모집', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into article_category (title, created_at, modified_at) values ('공지 사항', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+-- insert into article_category (title, created_at, modified_at) values ('이벤트', now(), now()) ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- -- 게시글 테스트 데이터
+-- insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
+--     values ("게시글1 제목입니다!!", "게겍게겍ㄲ", 10, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
+--         ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
+-- values ("게시글2 제목입니다!!", "게겍게겍ㄲ", 5, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
+--     ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
+-- values ("게시글3 제목입니다!!", "게겍게겍ㄲ", 100, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
+--     ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
+-- values ("게시글4 제목입니다!!", "게겍게겍ㄲ", 1, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
+--     ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- insert into article(title, content, likes_count, dislikes_count, article_category_id, board_id, user_id, created_at, created_by, modified_at, modified_by)
+-- values ("게시글 제목입니다5!!", "게겍게겍ㄲ", 54, 0, 1, 1, 1, now(), "게시글 작성자", now(), "게시글 작성자")
+--     ON DUPLICATE KEY UPDATE `title`=VALUES(`title`);
+--
+-- -- 게시글 최상위 댓글 테스트 데이터
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+--     values ('댓글1 입니다!!!', 0, 0, 0, 2, 2, NULL, NULL, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자') ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('댓글2 입니다!!!', 0, 0, 0, 2, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('댓글3 입니다!!!', 0, 0, 0, 3, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('댓글4 입니다!!!', 0, 0, 0, 1, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('댓글5 입니다!!!', 0, 0, 0, 1, 2, null, null, now(), '게시글 최상위 작성자', now(), '게시글 최상위 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+--
+-- -- 게시글 대댓글 테스트 데이터
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('대댓글5 입니다!!!', 0, 0, 1, 4, 3, 3, NULL, now(), '대댓글 작성자', now(), '대댓글 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('대댓글5 입니다!!!', 0, 0, 1, 4, 3, 3, NULL, now(), '대댓글 작성자', now(), '대댓글 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);
+--
+-- insert into article_comment(content, likes_count, dislikes_count, is_child, article_id, user_id, parent_comment_id, recipient_id, created_at, created_by, modified_at, modified_by)
+-- values ('전 님 의견 반박합니다!!!!!!!', 0, 0, 1, 4, 3, 3, 3, now(), '대댓글 작성자', now(), '대댓글 작성자')
+--     ON DUPLICATE KEY UPDATE `content`=VALUES(`content`);


### PR DESCRIPTION
게시글을 생성 혹은 수정할 때, 게시글 1개당 해시태그의 최대 개수를 10개로 제한하도록 로직을 추가함

This closes #29 