### PR TITLE
스프링 통합테스트 에러 해결

### DIFF
--- a/spadeworker/src/main/java/com/study/spadeworker/global/config/security/SecurityConfig.java
+++ b/spadeworker/src/main/java/com/study/spadeworker/global/config/security/SecurityConfig.java
@@ -120,13 +120,13 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 
-    /*
-     * auth 매니저 설정
-     * */
-    @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
-        return authenticationConfiguration.getAuthenticationManager();
-    }
+//    /*
+//     * auth 매니저 설정
+//     * */
+//    @Bean
+//    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+//        return authenticationConfiguration.getAuthenticationManager();
+//    }
 
     /*
      * 토큰 필터 설정

--- a/spadeworker/src/test/java/com/study/spadeworker/SpadeworkerApplicationTests.java
+++ b/spadeworker/src/test/java/com/study/spadeworker/SpadeworkerApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class SpadeworkerApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
SpringSecurity의 Config 파일에서 AuthenticationManager를 설정하는 로직이 문제를 일으킨 것 으로 수정하여 주석처리한다. 정확한 원인은 향후 분석할 예정